### PR TITLE
Fixed wrong regex simplification and related tests with wrong expected results

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,13 @@ two nodes in the labeled graph.
 
 The implementation is according to chapter 2 of the paper
 [Fast Algorithms for Solving Path Problems](https://dl.acm.org/citation.cfm?id=322273).
-Please note that this is neither the algorithm with runtime $\mathcal{O}(m \alpha(m,n))$
-nor the algorithm with runtime $\mathcal{O}(m\log n)$ mentioned in the abstract of the
-paper.
+Please note that this is neither the algorithm with runtime *O(m α(m,n))*
+nor the algorithm with runtime *O(m log n)* mentioned in the abstract of the paper.
 
-For a fixed node $v$ this implementation computes path expressions from $v$ to $u$ for every node
-$u$ in the graph. Computing all these path expressions at once for a fixed $v$ has time complexity
-of at most $\mathcal{O}(n^3+m)$ with $n$ being the number of nodes in the graph and $m$ being the
-number of edges in the graph. For sparse graphs the time complexity may be substantially lower.
+For a fixed node *v* this implementation computes *n* path expressions --
+one path expression from *v* to *u* for every node *u* in the graph.
+Computing all these path expressions at once for a fixed *v* has time complexity
+of at most *O(n³+m)*. For sparse graphs the time complexity may be substantially lower.
+
+*n* = number of nodes in the graph\
+*m* = number of edges in the graph

--- a/README.md
+++ b/README.md
@@ -2,9 +2,17 @@
 
 # Path Expression
 
-This repository contains an implementation of an algorithm by Tarjan that efficiently computes path expressions based on a labeled graph.
-A path expression is a regular expression describing all path between two nodes in the labeled graph.
+This repository contains an implementation of an algorithm by Tarjan that computes path expressions
+based on a labeled graph. A path expression is a regular expression describing all paths between
+two nodes in the labeled graph.
 
-The implementation is according to the paper:
+The implementation is according to chapter 2 of the paper
+[Fast Algorithms for Solving Path Problems](https://dl.acm.org/citation.cfm?id=322273).
+Please note that this is neither the algorithm with runtime $\mathcal{O}(m \alpha(m,n))$
+nor the algorithm with runtime $\mathcal{O}(m\log n)$ mentioned in the abstract of the
+paper.
 
-[Fast Algorithms for Solving Path Problems](https://dl.acm.org/citation.cfm?id=322273)
+For a fixed node $v$ this implementation computes path expressions from $v$ to $u$ for every node
+$u$ in the graph. Computing all these path expressions at once for a fixed $v$ has time complexity
+of at most $\mathcal{O}(n^3+m)$ with $n$ being the number of nodes in the graph and $m$ being the
+number of edges in the graph. For sparse graphs the time complexity may be substantially lower.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-[![Run Status](https://api.shippable.com/projects/5ab50d83806e27070049c7a1/badge?branch=master)](https://app.shippable.com/github/johspaeth/PathExpression)
+**This is a copy of [johspaeth/PathExpression](https://github.com/johspaeth/PathExpression)
+created solely for
+[this pull request](https://github.com/johspaeth/PathExpression/pull/3).**
 
 # Path Expression
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,3 @@
-**This is a copy of [johspaeth/PathExpression](https://github.com/johspaeth/PathExpression)
-created solely for
-[this pull request](https://github.com/johspaeth/PathExpression/pull/3).**
-
 # Path Expression
 
 This repository contains an implementation of an algorithm by Tarjan that computes path expressions

--- a/src/main/java/pathexpression/Epsilon.java
+++ b/src/main/java/pathexpression/Epsilon.java
@@ -21,4 +21,14 @@ public class Epsilon<V> implements IRegEx<V> {
   public String toString() {
     return "EPS";
   }
+
+  @Override
+  public int hashCode() {
+    return 2012345681;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    return obj instanceof Epsilon;
+  }
 }

--- a/src/main/java/pathexpression/PathExpressionComputer.java
+++ b/src/main/java/pathexpression/PathExpressionComputer.java
@@ -12,9 +12,7 @@
 
 package pathexpression;
 
-import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBasedTable;
-import com.google.common.collect.HashBiMap;
 import com.google.common.collect.Table;
 import pathexpression.RegEx.EmptySet;
 
@@ -32,7 +30,7 @@ public class PathExpressionComputer<N, V> {
   final static Logger logger = LogManager.getLogger(PathExpressionComputer.class);
 
   private LabeledGraph<N, V> graph;
-  private BiMap<N, Integer> nodeToIntMap = HashBiMap.create();
+  private Map<N, Integer> nodeToIntMap = new HashMap<>();
   private Table<Integer, Integer, IRegEx<V>> table = HashBasedTable.create();
   private IRegEx<V> emptyRegEx = new RegEx.EmptySet<V>();
   private Map<N,List<IRegEx<V>>> allPathFromNode = new HashMap<>();
@@ -47,7 +45,7 @@ public class PathExpressionComputer<N, V> {
   private void initNodesToIntMap() {
     int size = nodeToIntMap.size();
     for (N node : graph.getNodes()) {
-      nodeToIntMap.put(node, (++size));
+      nodeToIntMap.put(node, ++size);
     }
   }
 
@@ -69,7 +67,7 @@ public class PathExpressionComputer<N, V> {
     if(allPathFromNode.get(a) != null) {
     		return allPathFromNode.get(a);
     }
-    
+
     eliminate();
     logger.debug("Compute all path from {}", a);
     List<PathExpression<V>> extractPathSequence = extractPathSequence();

--- a/src/main/java/pathexpression/PathExpressionComputer.java
+++ b/src/main/java/pathexpression/PathExpressionComputer.java
@@ -130,15 +130,12 @@ public class PathExpressionComputer<N, V> {
 	}
 	logger.debug("Start eliminating");
     int numberOfNodes = graph.getNodes().size();
+    // TODO eliminate this n^2 loop by using default value emptyRegEx
+    // Create a new method returning default value when table entry doesn't exist
+    // and use that method instead of table.get(...).
     for (int v = 1; v <= numberOfNodes; v++) {
       for (int w = 1; w <= numberOfNodes; w++) {
-        if (v == w) {
-          // This is different from Tarjan's ELIMINATE
-          // but doesn't seem to fix the problem when removed
-          updateTable(v, w, new Epsilon());
-        } else {
-          updateTable(v, w, emptyRegEx);
-        }
+        updateTable(v, w, emptyRegEx);
       }
     }
     for (Edge<N, V> e : graph.getEdges()) {

--- a/src/main/java/pathexpression/PathExpressionComputer.java
+++ b/src/main/java/pathexpression/PathExpressionComputer.java
@@ -133,6 +133,8 @@ public class PathExpressionComputer<N, V> {
     for (int v = 1; v <= numberOfNodes; v++) {
       for (int w = 1; w <= numberOfNodes; w++) {
         if (v == w) {
+          // This is different from Tarjan's ELIMINATE
+          // but doesn't seem to fix the problem when removed
           updateTable(v, w, new Epsilon());
         } else {
           updateTable(v, w, emptyRegEx);

--- a/src/main/java/pathexpression/RegEx.java
+++ b/src/main/java/pathexpression/RegEx.java
@@ -238,12 +238,6 @@ public class RegEx<V> implements IRegEx<V> {
         return u.getFirst();
       if (u.getFirst().equals(u.getSecond()))
         return u.getFirst();
-      // TODO this is neither part of Tarjan's regex simplification operator [ ]
-      //      nor correct. (a U ε) = (ε U a) ≠ a  // with a∊Σ
-      if(u.getFirst() instanceof Epsilon)
-        return u.getSecond();
-      if(u.getSecond() instanceof Epsilon)
-        return u.getFirst();
     }
     if (in instanceof Concatenate) {
       Concatenate<V> c = (Concatenate<V>) in;
@@ -260,12 +254,11 @@ public class RegEx<V> implements IRegEx<V> {
     }
 
     if (in instanceof Star) {
-      Star<V> star = (Star<V>) in;
-      if (star.getPlain() instanceof EmptySet) {
-        return star.getPlain();
-      }
-      if (star.getPlain() instanceof Epsilon)
-        return star.getPlain();
+      IRegEx<V> starPlain = ((Star<V>) in).getPlain();
+      if (starPlain instanceof EmptySet)
+        return new Epsilon<V>();
+      if (starPlain instanceof Epsilon)
+        return starPlain;
     }
 
     return in;
@@ -312,6 +305,11 @@ public class RegEx<V> implements IRegEx<V> {
   public static class EmptySet<V> implements IRegEx<V> {
     public String toString() {
       return "EMPTY";
+    }
+
+    @Override
+    public int hashCode() {
+      return 987656707;
     }
 
     @Override

--- a/src/main/java/pathexpression/RegEx.java
+++ b/src/main/java/pathexpression/RegEx.java
@@ -238,6 +238,8 @@ public class RegEx<V> implements IRegEx<V> {
         return u.getFirst();
       if (u.getFirst().equals(u.getSecond()))
         return u.getFirst();
+      // TODO this is neither part of Tarjan's regex simplification operator [ ]
+      //      nor correct. (a U ε) = (ε U a) ≠ a  // with a∊Σ
       if(u.getFirst() instanceof Epsilon)
         return u.getSecond();
       if(u.getSecond() instanceof Epsilon)

--- a/src/test/java/test/PathExpressionTest.java
+++ b/src/test/java/test/PathExpressionTest.java
@@ -225,6 +225,10 @@ public class PathExpressionTest {
     g.addEdge(4, "41", 1);
     PathExpressionComputer<Integer, String> expr = new PathExpressionComputer<Integer, String>(g);
     IRegEx<String> expressionBetween = expr.getExpressionBetween(1, 1);
+    // TODO expected regex not correct.
+    // Empty word ε should be accepted by path expression from 1 to 1.
+    // Currently        12·23·(32·23)*·34·[41·12·23·(32·23)*·34]*·41
+    // Should be  EPS U 12·23·(32·23)*·34·[41·12·23·(32·23)*·34]*·41
     IRegEx<String> expected = a(a(a(a(a("12", "23"), star(a("32", "23"))), "34"), star(a(a(a(a("41", "12"), "23"), star(a("32", "23"))), "34"))), "41");
     assertEquals(expected, expressionBetween);
   }
@@ -238,6 +242,10 @@ public class PathExpressionTest {
     g.addEdge(4, "41", 1);
     PathExpressionComputer<Integer, String> expr = new PathExpressionComputer<Integer, String>(g);
     IRegEx<String> expressionBetween = expr.getExpressionBetween(1, 1);
+    // TODO expected regex not correct.
+    // Empty word ε should be accepted by path expression from 1 to 1.
+    // Currently        13·(31·13)*·34·[41·13·(31·13)*·34]*·41 U ...
+    // Should be  EPS U 13·(31·13)*·34·[41·13·(31·13)*·34]*·41 U ...
     IRegEx<String> expected = u(a(a(a(a("13", star(a("31", "13"))), "34"), star(a(a(a("41", "13"), star(a("31", "13"))), "34"))), "41"), a(u(a("13", star(a("31", "13"))), a(a(a(a("13", star(a("31", "13"))), "34"), star(a(a(a("41", "13"), star(a("31", "13"))), "34"))), a(a("41", "13"), star(a("31", "13"))))), "31"));
     assertEquals(expected, expressionBetween);
   }

--- a/src/test/java/test/PathExpressionTest.java
+++ b/src/test/java/test/PathExpressionTest.java
@@ -18,7 +18,7 @@ import org.junit.Test;
 import pathexpression.IRegEx;
 import pathexpression.PathExpressionComputer;
 import pathexpression.RegEx;
-
+import pathexpression.Epsilon;
 
 public class PathExpressionTest {
    @Test
@@ -225,11 +225,7 @@ public class PathExpressionTest {
     g.addEdge(4, "41", 1);
     PathExpressionComputer<Integer, String> expr = new PathExpressionComputer<Integer, String>(g);
     IRegEx<String> expressionBetween = expr.getExpressionBetween(1, 1);
-    // TODO expected regex not correct.
-    // Empty word ε should be accepted by path expression from 1 to 1.
-    // Currently        12·23·(32·23)*·34·[41·12·23·(32·23)*·34]*·41
-    // Should be  EPS U 12·23·(32·23)*·34·[41·12·23·(32·23)*·34]*·41
-    IRegEx<String> expected = a(a(a(a(a("12", "23"), star(a("32", "23"))), "34"), star(a(a(a(a("41", "12"), "23"), star(a("32", "23"))), "34"))), "41");
+    IRegEx<String> expected = u(new Epsilon<String>(), a(a(a(a(a("12", "23"), star(a("32", "23"))), "34"), star(a(a(a(a("41", "12"), "23"), star(a("32", "23"))), "34"))), "41"));
     assertEquals(expected, expressionBetween);
   }
 
@@ -242,18 +238,13 @@ public class PathExpressionTest {
     g.addEdge(4, "41", 1);
     PathExpressionComputer<Integer, String> expr = new PathExpressionComputer<Integer, String>(g);
     IRegEx<String> expressionBetween = expr.getExpressionBetween(1, 1);
-    // TODO expected regex not correct.
-    // Empty word ε should be accepted by path expression from 1 to 1.
-    // Currently        13·(31·13)*·34·[41·13·(31·13)*·34]*·41 U ...
-    // Should be  EPS U 13·(31·13)*·34·[41·13·(31·13)*·34]*·41 U ...
-    IRegEx<String> expected = u(a(a(a(a("13", star(a("31", "13"))), "34"), star(a(a(a("41", "13"), star(a("31", "13"))), "34"))), "41"), a(u(a("13", star(a("31", "13"))), a(a(a(a("13", star(a("31", "13"))), "34"), star(a(a(a("41", "13"), star(a("31", "13"))), "34"))), a(a("41", "13"), star(a("31", "13"))))), "31"));
+    IRegEx<String> expected = u(u(new Epsilon<String>(), a(a(a(a("13", star(a("31", "13"))), "34"), star(a(a(a("41", "13"), star(a("31", "13"))), "34"))), "41")), a(u(a("13", star(a("31", "13"))), a(a(a(a("13", star(a("31", "13"))), "34"), star(a(a(a("41", "13"), star(a("31", "13"))), "34"))), a(a("41", "13"), star(a("31", "13"))))), "31"));
     assertEquals(expected, expressionBetween);
   }
 
   private static IRegEx<String> e(String e) {
     return new RegEx.Plain<String>(e);
   }
-
 
   private static IRegEx<String> a(IRegEx<String> a, IRegEx<String> b) {
     return RegEx.<String>concatenate(a, b);

--- a/src/test/java/test/PathExpressionTest.java
+++ b/src/test/java/test/PathExpressionTest.java
@@ -168,19 +168,6 @@ public class PathExpressionTest {
   public void branchWithEps2() {
     IntGraph g = new IntGraph();
     g.addEdge(1, "a", 2);
-    g.addEdge(2, "v", 4);
-    g.addEdge(1, "c", 3);
-    g.addEdge(1, "c", 4);
-    PathExpressionComputer<Integer, String> expr = new PathExpressionComputer<Integer, String>(g);
-    IRegEx<String> expressionBetween = expr.getExpressionBetween(1, 4);
-    IRegEx<String> expected = u("c", a("a", "v"));
-    assertEquals(expected, expressionBetween);
-  }
-
-  @Test
-  public void branchWithEps3() {
-    IntGraph g = new IntGraph();
-    g.addEdge(1, "a", 2);
     g.addEdge(2, "v", 3);
     g.addEdge(1, "c", 3);
     PathExpressionComputer<Integer, String> expr = new PathExpressionComputer<Integer, String>(g);


### PR DESCRIPTION
Fixed bug mentioned in prior pull request https://github.com/johspaeth/PathExpression/pull/2.

Fixed wrong simplifications.
Before:
```
simplify(a ∪ ε) = a
simplify(∅*) = ∅
```
After:
```
simplify(a ∪ ε) = a ∪ ε
simplify(∅*) = ε
```

Fixed wrong expected results in test cases `loop3` and `loop4`.

Removed `if (v == w) updateTable(v, w, new Epsilon()` because it is neither part of the original algorithm nor provides any benefits. `pvv = RegEx.<V>star(pvv); updateTable(v, v, pvv)` does
the same when simplification is implemented correctly.

Not related to the bug:
- Added note on how to eliminate O(n^2) loop using default values.
- Implemented `equals` and `hashCode` for class `Epsilon` and `hashCode` for
class `RegEx.EmptySet`. However, implementing both classes as singletons
would be better.
- Added more information to README.md regarding time complexity.